### PR TITLE
Add support for https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 21/02/2025 0.9.24
+
+- Added support for epson printers communicating over SSL
+
 ## 31/03/2023 0.9.11
 
 - Bugfix for Symbols

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baemingo/epson-printer-sdk",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "A modern and simple \"connect-less\" integration against EPSON printers",
   "license": "MIT",
   "publishConfig": {

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -10,9 +10,8 @@ const EPSON_XML_HEADER =
 class EpsonPrinter {
   private url;
 
-  constructor(ip: string, useSsl?: boolean)
-  {
-	  this.url = `${useSsl == true ? 'https' : 'http'}://${ip}/cgi-bin/epos/service.cgi?devid=local_printer&timeout=10000`
+  constructor(ip: string, useSsl = false) {
+	  this.url = `${useSsl ? 'https' : 'http'}://${ip}/cgi-bin/epos/service.cgi?devid=local_printer&timeout=10000`
   }
 
   public async send(print: EpsonPrint) {

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -10,8 +10,9 @@ const EPSON_XML_HEADER =
 class EpsonPrinter {
   private url;
 
-  constructor(ip: string) {
-    this.url = `http://${ip}/cgi-bin/epos/service.cgi?devid=local_printer&timeout=10000`;
+  constructor(ip: string, useSsl?: boolean)
+  {
+	  this.url = `${useSsl == true ? 'https' : 'http'}://${ip}/cgi-bin/epos/service.cgi?devid=local_printer&timeout=10000`
   }
 
   public async send(print: EpsonPrint) {


### PR DESCRIPTION
Added an extra (optional) constructor argument 'useSsl' (that defaults to false = backward compatible).